### PR TITLE
Update bp-groups-externalblogs.php

### DIFF
--- a/includes/bp-groups-externalblogs.php
+++ b/includes/bp-groups-externalblogs.php
@@ -339,6 +339,7 @@ if ( class_exists('BP_Group_Extension' ) ) {
 				// save rss guid as activity meta
 				bp_activity_update_meta( $aid, 'exb_guid', $post['guid'] );
 				bp_activity_update_meta( $aid, 'exb_feedurl', $post['feedurl'] );
+				groups_update_groupmeta( $group_id, 'last_activity', bp_core_current_time() );
 			}
 		}
 


### PR DESCRIPTION
As per my bug report, this is the change that should be made. This will solve the problem that external blogs do not update the last active time for their group.